### PR TITLE
Bees: fix [-Werror=implicit-fallthrough=]

### DIFF
--- a/lib/extentwalker.cc
+++ b/lib/extentwalker.cc
@@ -520,25 +520,26 @@ namespace crucible {
 
 			auto type = call_btrfs_get(btrfs_stack_file_extent_type, i.m_data);
 			off_t len = -1;
-                        switch (type) {
-                                default:
+			switch (type) {
+				default:
 					cerr << "Unhandled file extent type " << type << " in root " << m_tree_id << " ino " << m_stat.st_ino << endl;
 					break;
-                                case BTRFS_FILE_EXTENT_INLINE:
+				case BTRFS_FILE_EXTENT_INLINE:
 					len = ranged_cast<off_t>(call_btrfs_get(btrfs_stack_file_extent_ram_bytes, i.m_data));
 					e.m_flags |= FIEMAP_EXTENT_DATA_INLINE | FIEMAP_EXTENT_NOT_ALIGNED;
 					// Inline extents are never obscured, so don't bother filling in m_physical_len, etc.
-                                        break;
-                                case BTRFS_FILE_EXTENT_PREALLOC:
+					break;
+				case BTRFS_FILE_EXTENT_PREALLOC:
 					e.m_flags |= Extent::PREALLOC;
-                                case BTRFS_FILE_EXTENT_REG: {
+					// fallthrough
+				case BTRFS_FILE_EXTENT_REG: {
 					e.m_physical = call_btrfs_get(btrfs_stack_file_extent_disk_bytenr, i.m_data);
 
 					// This is the length of the full extent (decompressed)
-                                        off_t ram = ranged_cast<off_t>(call_btrfs_get(btrfs_stack_file_extent_ram_bytes, i.m_data));
+					off_t ram = ranged_cast<off_t>(call_btrfs_get(btrfs_stack_file_extent_ram_bytes, i.m_data));
 
 					// This is the length of the part of the extent appearing in the file (decompressed)
-                                        len = ranged_cast<off_t>(call_btrfs_get(btrfs_stack_file_extent_num_bytes, i.m_data));
+					len = ranged_cast<off_t>(call_btrfs_get(btrfs_stack_file_extent_num_bytes, i.m_data));
 
 					// This is the offset from start of on-disk extent to the part we see in the file (decompressed)
 					// May be negative due to the kind of bug we're stuck with forever, so no cast range check

--- a/src/bees-roots.cc
+++ b/src/bees-roots.cc
@@ -768,6 +768,7 @@ BeesCrawl::fetch_extents()
 				break;
 			case BTRFS_FILE_EXTENT_PREALLOC:
 				BEESCOUNT(crawl_prealloc);
+				// fallthrough
 			case BTRFS_FILE_EXTENT_REG: {
 				auto physical = call_btrfs_get(btrfs_stack_file_extent_disk_bytenr, i.m_data);
 				auto ram = call_btrfs_get(btrfs_stack_file_extent_ram_bytes, i.m_data);


### PR DESCRIPTION
In gcc 7+ warning: implicit-fallthrough has been added
In some places fallthrough is expectable, disable warning

Also fix space indentation

Signed-off-by: Timofey Titovets <nefelim4ag@gmail.com>