### PR TITLE
Don't zap localconf in "make clean"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MARKDOWN ?= markdown
 default all: lib src test README.html
 
 clean: ## Cleanup
-	git clean -dfx
+	git clean -dfx -e localconf
 
 .PHONY: lib src test
 


### PR DESCRIPTION
When you run "make clean", localconf is being removed. This is probably
in most cases not intentional.

Signed-off-by: Kai Krakow <kai@kaishome.de>