### PR TITLE
Fix: exec bees - breaks bash trap handling of umount bees workdir

### DIFF
--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -115,4 +115,5 @@ fi
 
 MNT_DIR="${MNT_DIR//\/\//\/}"
 
-cd $MNT_DIR && exec @LIBEXEC_PREFIX@/bees ${ARGUMENTS[@]} $OPTIONS "$MNT_DIR"
+cd "$MNT_DIR"
+@LIBEXEC_PREFIX@/bees "${ARGUMENTS[@]}" $OPTIONS "$MNT_DIR"


### PR DESCRIPTION
Signed-off-by: Timofey Titovets <nefelim4ag@gmail.com>