### PR TITLE
Proposal: Big Makefile overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.[ao]
 *.bak
 *.new
+*.dep
 *.so*
 Doxyfile
 README.html

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: lib src
 	$(MAKE) -C test
 
 scripts/%: scripts/%.in
-	sed -e's#@LIBEXEC_PREFIX@#$(LIBEXEC_PREFIX)#' -e's#@PREFIX@#$(PREFIX)#' "$<" >"$@"
+	sed -e's#@LIBEXEC_PREFIX@#$(LIBEXEC_PREFIX)#' -e's#@PREFIX@#$(PREFIX)#' $< >$@
 
 scripts: scripts/beesd scripts/beesd@.service
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -31,7 +31,7 @@ depends.mk: *.cc
 
 include depends.mk
 
-%.o: %.cc ../include/crucible/%.h
+%.o: %.cc ../makeflags
 	$(CXX) $(CXXFLAGS) -fPIC -o $@ -c $<
 
 libcrucible.so: $(OBJS) Makefile

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -24,8 +24,12 @@ libcrucible.so: $(CRUCIBLE_OBJS)
 
 include ../makeflags
 
-depends.mk: *.cc
-	for x in $^; do $(CXX) $(CXXFLAGS) -M -MG -MT "$${x/%.cc/.o}" "$$x"; done > $@.new
+.depends/%.dep: %.cc Makefile
+	@mkdir -p .depends
+	$(CXX) $(CXXFLAGS) -M -MF $@ -MT $(<:.cc=.o) $<
+
+depends.mk: $(CRUCIBLE_OBJS:%.o=.depends/%.dep)
+	cat $^ > $@.new
 	mv -f $@.new $@
 
 .version.cc: Makefile ../makeflags *.cc ../include/crucible/*.h

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -25,8 +25,8 @@ libcrucible.so: $(CRUCIBLE_OBJS)
 include ../makeflags
 
 depends.mk: *.cc
-	for x in *.cc; do $(CXX) $(CXXFLAGS) -M "$$x"; done > depends.mk.new
-	mv -fv depends.mk.new depends.mk
+	for x in $^; do $(CXX) $(CXXFLAGS) -M -MG -MT "$${x/%.cc/.o}" "$$x"; done > $@.new
+	mv -fv $@.new $@
 
 .version.cc: Makefile ../makeflags *.cc ../include/crucible/*.h
 	echo "namespace crucible { const char *VERSION = \"$(TAG)\"; }" > .version.new.cc

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,7 @@
 TAG := $(shell git describe --always --dirty || echo UNKNOWN)
 
 default: libcrucible.so
+%.so: Makefile
 
 OBJS = \
 	chatter.o \
@@ -19,6 +20,8 @@ OBJS = \
 	uuid.o \
 	.version.o \
 
+libcrucible.so: $(OBJS)
+
 include ../makeflags
 
 depends.mk: *.cc
@@ -34,5 +37,5 @@ include depends.mk
 %.o: %.cc ../makeflags
 	$(CXX) $(CXXFLAGS) -fPIC -o $@ -c $<
 
-libcrucible.so: $(OBJS) Makefile
-	$(CXX) $(LDFLAGS) -fPIC -o $@ $(OBJS) -shared -Wl,-soname,$@ -luuid
+%.so:
+	$(CXX) $(LDFLAGS) -fPIC -o $@ $^ -shared -Wl,-soname,$@ -luuid

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -29,7 +29,7 @@ depends.mk: *.cc
 	echo "namespace crucible { const char *VERSION = \"$(TAG)\"; }" > .version.new.cc
 	mv -f .version.new.cc .version.cc
 
--include depends.mk
+include depends.mk
 
 %.o: %.cc ../include/crucible/%.h
 	$(CXX) $(CXXFLAGS) -fPIC -o $@ -c $<

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -3,7 +3,7 @@ TAG := $(shell git describe --always --dirty || echo UNKNOWN)
 default: libcrucible.so
 %.so: Makefile
 
-OBJS = \
+CRUCIBLE_OBJS = \
 	chatter.o \
 	cleanup.o \
 	crc64.o \
@@ -20,7 +20,7 @@ OBJS = \
 	uuid.o \
 	.version.o \
 
-libcrucible.so: $(OBJS)
+libcrucible.so: $(CRUCIBLE_OBJS)
 
 include ../makeflags
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -29,8 +29,8 @@ depends.mk: *.cc
 	mv -fv $@.new $@
 
 .version.cc: Makefile ../makeflags *.cc ../include/crucible/*.h
-	echo "namespace crucible { const char *VERSION = \"$(TAG)\"; }" > .version.new.cc
-	mv -f .version.new.cc .version.cc
+	echo "namespace crucible { const char *VERSION = \"$(TAG)\"; }" > $@.new
+	mv -f $@.new $@
 
 include depends.mk
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -20,7 +20,7 @@ CRUCIBLE_OBJS = \
 	uuid.o \
 	.version.o \
 
-libcrucible.so: $(CRUCIBLE_OBJS)
+libcrucible.so: $(CRUCIBLE_OBJS) -luuid
 
 include ../makeflags
 
@@ -42,4 +42,4 @@ include depends.mk
 	$(CXX) $(CXXFLAGS) -fPIC -o $@ -c $<
 
 %.so:
-	$(CXX) $(LDFLAGS) -fPIC -o $@ $^ -shared -Wl,-soname,$@ -luuid
+	$(CXX) $(LDFLAGS) -fPIC -shared -Wl,-soname,$@ -o $@ $^

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -26,7 +26,7 @@ include ../makeflags
 
 depends.mk: *.cc
 	for x in $^; do $(CXX) $(CXXFLAGS) -M -MG -MT "$${x/%.cc/.o}" "$$x"; done > $@.new
-	mv -fv $@.new $@
+	mv -f $@.new $@
 
 .version.cc: Makefile ../makeflags *.cc ../include/crucible/*.h
 	echo "namespace crucible { const char *VERSION = \"$(TAG)\"; }" > $@.new

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,7 +18,7 @@ bees-version.c: Makefile *.cc *.h
 	echo "const char *BEES_VERSION = \"$(shell git describe --always --dirty || echo UNKNOWN)\";" > bees-version.new.c
 	mv -f bees-version.new.c bees-version.c
 
--include depends.mk
+include depends.mk
 
 %.o: %.cc %.h
 	$(CXX) $(CXXFLAGS) -o "$@" -c "$<"

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@ PROGRAMS = \
 	../bin/fiemap \
 	../bin/fiewalk \
 
-all: $(PROGRAMS) depends.mk
+all: $(PROGRAMS)
 
 include ../makeflags
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,23 +10,6 @@ include ../makeflags
 LIBS = -lcrucible -lpthread
 LDFLAGS = -L../lib
 
-depends.mk: Makefile *.cc
-	for x in *.cc; do $(CXX) $(CXXFLAGS) -M "$$x"; done > depends.mk.new
-	mv -fv depends.mk.new depends.mk
-
-bees-version.c: Makefile *.cc *.h
-	echo "const char *BEES_VERSION = \"$(shell git describe --always --dirty || echo UNKNOWN)\";" > bees-version.new.c
-	mv -f bees-version.new.c bees-version.c
-
-include depends.mk
-
-%.o: %.cc %.h
-	$(CXX) $(CXXFLAGS) -o "$@" -c "$<"
-
-../bin/%: %.o
-	@echo Implicit bin rule "$<" '->' "$@"
-	$(CXX) $(CXXFLAGS) -o "$@" "$<" $(LDFLAGS) $(LIBS)
-
 BEES_OBJS = \
 	bees.o \
 	bees-context.o \
@@ -35,10 +18,30 @@ BEES_OBJS = \
 	bees-roots.o \
 	bees-thread.o \
 	bees-types.o \
-	bees-version.o \
 
-../bin/bees: $(BEES_OBJS)
-	$(CXX) $(CXXFLAGS) -o "$@" $(BEES_OBJS) $(LDFLAGS) $(LIBS)
+bees-version.c: bees.h $(BEES_OBJS:.o=.cc) Makefile
+	echo "const char *BEES_VERSION = \"$(shell git describe --always --dirty || echo UNKNOWN)\";" > bees-version.new.c
+	mv -f bees-version.new.c bees-version.c
+
+.depends/%.dep: %.cc Makefile
+	@mkdir -p .depends
+	$(CXX) $(CXXFLAGS) -M -MF $@ -MT $(<:.cc=.o) $<
+
+depends.mk: $(BEES_OBJS:%.o=.depends/%.dep)
+	cat $^ > $@.new
+	mv -f $@.new $@
+
+include depends.mk
+
+%.o: %.cc %.h
+	$(CXX) $(CXXFLAGS) -o "$@" -c "$<"
+
+../bin/%: %.o
+	@echo Implicit bin rule "$<" '->' "$@"
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LIBS) -o $@ $<
+
+../bin/bees: $(BEES_OBJS) bees-version.o
+	$(CXX) $(CXXFLAGS) -o "$@" $^ $(LDFLAGS) $(LIBS)
 
 clean:
 	-rm -fv bees-version.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,15 +34,14 @@ depends.mk: $(BEES_OBJS:%.o=.depends/%.dep)
 include depends.mk
 
 %.o: %.cc %.h
-	$(CXX) $(CXXFLAGS) -o "$@" -c "$<"
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 ../bin/%: %.o
 	@echo Implicit bin rule "$<" '->' "$@"
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LIBS) -o $@ $<
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $< $(LIBS)
 
 ../bin/bees: $(BEES_OBJS) bees-version.o
-	$(CXX) $(CXXFLAGS) -o "$@" $^ $(LDFLAGS) $(LIBS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 clean:
-	-rm -fv bees-version.h
-	-rm -fv *.o bees-version.c
+	rm -fv *.o bees-version.c

--- a/test/Makefile
+++ b/test/Makefile
@@ -28,12 +28,12 @@ depends.mk: $(PROGRAMS:%=.depends/%.dep)
 include depends.mk
 
 %.o: %.cc %.h ../makeflags
-	-echo "Implicit rule %.o: %.cc" >&2
-	$(CXX) $(CXXFLAGS) -o "$@" -c "$<"
+	@echo "Implicit rule %.o: %.cc"
+	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 %: %.o ../makeflags
-	-echo "Implicit rule %: %.o" >&2
-	$(CXX) $(CXXFLAGS) -o "$@" "$<" $(LDFLAGS) $(LIBS)
+	@echo "Implicit rule %: %.o"
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LIBS) -o $@ $<
 
 clean:
-	-rm -fv *.o
+	rm -fv *.o

--- a/test/Makefile
+++ b/test/Makefile
@@ -17,9 +17,13 @@ include ../makeflags
 LIBS = -lcrucible -lpthread
 LDFLAGS = -L../lib -Wl,-rpath=$(shell realpath ../lib)
 
-depends.mk: *.cc
-	for x in *.cc; do $(CXX) $(CXXFLAGS) -M "$$x"; done > depends.mk.new
-	mv -fv depends.mk.new depends.mk
+.depends/%.dep: %.cc
+	@mkdir -p .depends
+	$(CXX) $(CXXFLAGS) -M -MF $@ -MT $(<:.cc=.o) $<
+
+depends.mk: $(PROGRAMS:%=.depends/%.dep)
+	cat $^ > $@.new
+	mv -f $@.new $@
 
 include depends.mk
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,7 +21,7 @@ depends.mk: *.cc
 	for x in *.cc; do $(CXX) $(CXXFLAGS) -M "$$x"; done > depends.mk.new
 	mv -fv depends.mk.new depends.mk
 
--include depends.mk
+include depends.mk
 
 %.o: %.cc %.h ../makeflags
 	-echo "Implicit rule %.o: %.cc" >&2

--- a/test/Makefile
+++ b/test/Makefile
@@ -17,7 +17,7 @@ include ../makeflags
 LIBS = -lcrucible -lpthread
 LDFLAGS = -L../lib -Wl,-rpath=$(shell realpath ../lib)
 
-.depends/%.dep: %.cc
+.depends/%.dep: %.cc tests.h Makefile
 	@mkdir -p .depends
 	$(CXX) $(CXXFLAGS) -M -MF $@ -MT $(<:.cc=.o) $<
 


### PR DESCRIPTION
I'm starting to work on a configuration file reader and a configuration registry. To prepare for that, I'd like to move the build sources of libcrucible.so into their own sub directory. This also reflects the structure used in the include directory. On the way, I reorganized the Makefile, and also optimized it.

@Zygo:

The last commit moves `lib/*.cc` to `lib/crucible/*.cc`. You may want to check if your other branches rebase or merge correctly. Please review, feel free to pull if it looks good to you. Otherwise, let me know what should be changed.