### PR TITLE
Makefile: Specify version when building from tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ SYSTEMD_SYSTEM_UNIT_DIR ?= $(shell pkg-config systemd --variable=systemdsystemun
 
 MARKDOWN := $(firstword $(shell type -P markdown markdown2 markdown_py 2>/dev/null || echo markdown))
 
+BEES_VERSION ?= $(shell git describe --always --dirty || echo UNKNOWN)
+
 # allow local configuration to override above variables
 -include localconf
 
@@ -36,7 +38,7 @@ lib: ## Build libs
 
 src: ## Build bins
 src: lib
-	$(MAKE) -C src
+	$(MAKE) BEES_VERSION="$(BEES_VERSION)" -C src
 
 test: ## Run tests
 test: lib src

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ BEES_OBJS = \
 	bees-types.o \
 
 bees-version.c: bees.h $(BEES_OBJS:.o=.cc) Makefile
-	echo "const char *BEES_VERSION = \"$(shell git describe --always --dirty || echo UNKNOWN)\";" > bees-version.new.c
+	echo "const char *BEES_VERSION = \"$(BEES_VERSION)\";" > bees-version.new.c
 	mv -f bees-version.new.c bees-version.c
 
 .depends/%.dep: %.cc Makefile


### PR DESCRIPTION
When package maintainers build from a tarball, the .git directory does
not exist to extract the version tag. Let's add a hack to work around
this issue and let them specify `BEES_VERSION="v0.y"` on the make
cmdline.

Github-Bug: https://github.com/Zygo/bees/issues/75
Signed-off-by: Kai Krakow <kai@kaishome.de>