### PR TITLE
systemd service replace deprecated parameters

### DIFF
--- a/scripts/beesd@.service.in
+++ b/scripts/beesd@.service.in
@@ -6,20 +6,19 @@ After=sysinit.target
 [Service]
 Type=simple
 ExecStart=@PREFIX@/sbin/beesd --no-timestamps %i
-Nice=19
-KillMode=control-group
-KillSignal=SIGTERM
-CPUShares=128
-StartupCPUShares=256
-BlockIOWeight=100
-StartupBlockIOWeight=250
+CPUAccounting=true
+CPUSchedulingPolicy=batch
+CPUWeight=12
 IOSchedulingClass=idle
 IOSchedulingPriority=7
-CPUSchedulingPolicy=batch
+IOWeight=10
+KillMode=control-group
+KillSignal=SIGTERM
+MemoryAccounting=true
 Nice=19
 Restart=on-abnormal
-CPUAccounting=true
-MemoryAccounting=true
+StartupCPUWeight=25
+StartupIOWeight=25
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
Replace CPU shares and IO block weight by CPU weight and IO weight. Note that new parameters are roughly 1/100 of old one--I believe that's the right conversion. Also removed duplicate Nice parameter and alphabetized the parameters for ease of reading.