### PR TITLE
[discussion] Tracking v0.6.y - not for merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ SYSTEMD_SYSTEM_UNIT_DIR ?= $(shell pkg-config systemd --variable=systemdsystemun
 
 MARKDOWN := $(firstword $(shell type -P markdown markdown2 markdown_py 2>/dev/null || echo markdown))
 
+BEES_VERSION ?= $(shell git describe --always --dirty || echo UNKNOWN)
+
 # allow local configuration to override above variables
 -include localconf
 
@@ -36,7 +38,7 @@ lib: ## Build libs
 
 src: ## Build bins
 src: lib
-	$(MAKE) -C src
+	$(MAKE) BEES_VERSION="$(BEES_VERSION)" -C src
 
 test: ## Run tests
 test: lib src

--- a/include/crucible/btrfs.h
+++ b/include/crucible/btrfs.h
@@ -23,6 +23,7 @@
 #undef min
 #undef max
 #undef mutex
+#undef swap
 
 #ifndef BTRFS_FIRST_FREE_OBJECTID
 

--- a/scripts/beesd@.service.in
+++ b/scripts/beesd@.service.in
@@ -6,20 +6,19 @@ After=sysinit.target
 [Service]
 Type=simple
 ExecStart=@PREFIX@/sbin/beesd --no-timestamps %i
-Nice=19
-KillMode=control-group
-KillSignal=SIGTERM
-CPUShares=128
-StartupCPUShares=256
-BlockIOWeight=100
-StartupBlockIOWeight=250
+CPUAccounting=true
+CPUSchedulingPolicy=batch
+CPUWeight=12
 IOSchedulingClass=idle
 IOSchedulingPriority=7
-CPUSchedulingPolicy=batch
+IOWeight=10
+KillMode=control-group
+KillSignal=SIGTERM
+MemoryAccounting=true
 Nice=19
 Restart=on-abnormal
-CPUAccounting=true
-MemoryAccounting=true
+StartupCPUWeight=25
+StartupIOWeight=25
 
 [Install]
 WantedBy=basic.target

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,1 +1,2 @@
 bees-version.[ch]
+bees-version.new.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ BEES_OBJS = \
 	bees-types.o \
 
 bees-version.c: bees.h $(BEES_OBJS:.o=.cc) Makefile
-	echo "const char *BEES_VERSION = \"$(shell git describe --always --dirty || echo UNKNOWN)\";" > bees-version.new.c
+	echo "const char *BEES_VERSION = \"$(BEES_VERSION)\";" > bees-version.new.c
 	mv -f bees-version.new.c bees-version.c
 
 .depends/%.dep: %.cc Makefile

--- a/src/bees-context.cc
+++ b/src/bees-context.cc
@@ -150,6 +150,10 @@ BeesContext::show_progress()
 Fd
 BeesContext::home_fd()
 {
+	if (!!m_home_fd) {
+		return m_home_fd;
+	}
+
 	const char *base_dir = getenv("BEESHOME");
 	if (!base_dir) {
 		base_dir = ".beeshome";

--- a/src/bees-roots.cc
+++ b/src/bees-roots.cc
@@ -185,9 +185,12 @@ BeesRoots::transid_min()
 		return 0;
 	}
 	uint64_t rv = numeric_limits<uint64_t>::max();
+	const uint64_t max_rv = rv;
 	for (auto i : m_root_crawl_map) {
 		rv = min(rv, i.second->get_state_end().m_min_transid);
 	}
+	// If we get through this loop without setting rv, we'll create broken crawlers due to integer overflow.
+	THROW_CHECK2(runtime_error, rv, max_rv, max_rv > rv);
 	return rv;
 }
 

--- a/src/bees-roots.cc
+++ b/src/bees-roots.cc
@@ -46,8 +46,8 @@ BeesCrawlState::BeesCrawlState() :
 bool
 BeesCrawlState::operator<(const BeesCrawlState &that) const
 {
-	return tie(m_min_transid, m_objectid, m_offset, m_root, m_max_transid)
-		< tie(that.m_min_transid, that.m_objectid, that.m_offset, that.m_root, that.m_max_transid);
+	return tie(m_min_transid, m_max_transid, m_objectid, m_offset, m_root)
+		< tie(that.m_min_transid, that.m_max_transid, that.m_objectid, that.m_offset, that.m_root);
 }
 
 string

--- a/src/bees-roots.cc
+++ b/src/bees-roots.cc
@@ -527,6 +527,16 @@ BeesRoots::state_load()
 			loaded_state.m_started = d.at("started");
 		}
 		BEESLOGDEBUG("loaded_state " << loaded_state);
+		if (loaded_state.m_min_transid == numeric_limits<uint64_t>::max()) {
+			BEESLOGWARN("WARNING: root " << loaded_state.m_root << ": bad min_transid " << loaded_state.m_min_transid << ", resetting to 0");
+			loaded_state.m_min_transid = 0;
+			BEESCOUNT(bug_bad_min_transid);
+		}
+		if (loaded_state.m_max_transid == numeric_limits<uint64_t>::max()) {
+			BEESLOGWARN("WARNING: root " << loaded_state.m_root << ": bad max_transid " << loaded_state.m_max_transid << ", resetting to " << loaded_state.m_min_transid);
+			loaded_state.m_max_transid = loaded_state.m_min_transid;
+			BEESCOUNT(bug_bad_max_transid);
+		}
 		insert_root(loaded_state);
 	}
 }


### PR DESCRIPTION
@Zygo Since you are considering to tag a v0.6.1 version due to LOGICAL_INO_V2 memory usage, is this list of commits a good selection for a v0.6.1 tag?

I'd like to get in a fix for the gcc-8.2 build failure from issue #85. So I'm going to push one more commit soon.