### PR TITLE
Makefile: Fix git usage for non-git source archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ clean: ## Cleanup
 .PHONY: lib src test doc
 
 lib: ## Build libs
-	+$(MAKE) -C lib
+	+$(MAKE) TAG="$(BEES_VERSION)" -C lib
 
 src: ## Build bins
 src: lib

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,4 +1,4 @@
-TAG := $(shell git describe --always --dirty || echo UNKNOWN)
+TAG ?= $(shell git describe --always --dirty || echo UNKNOWN)
 
 default: libcrucible.so
 %.so: Makefile


### PR DESCRIPTION
We didn't take enough care to fix all invocations of git in this
scenario.

Fixes: 32d2739 ("Makefile: Specify version when building from tarball")
Signed-off-by: Kai Krakow <kai@kaishome.de>