### PR TITLE
crucible: SIGUNUSED is deprecated.

### DIFF
--- a/lib/process.cc
+++ b/lib/process.cc
@@ -14,6 +14,10 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 
+#ifndef SIGUNUSED
+#define SIGUNUSED SIGSYS
+#endif
+
 namespace crucible {
 	using namespace std;
 


### PR DESCRIPTION
Since glibc 2.26, SIGUNUSED has been removed. It is adviced that legacy
code uses SIGSYS instead (which has the same value "31").

Closes: https://github.com/Zygo/bees/issues/94
Signed-off-by: Kai Krakow <kk@netactive.de>