### PR TITLE
Fix gettid() ambiguity with glibc >= 2.30

### DIFF
--- a/include/crucible/process.h
+++ b/include/crucible/process.h
@@ -10,6 +10,10 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#if (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 30) || __GLIBC__ > 2
+#define SYS_GETTID 1
+#endif  // __GLIBC__ && __GLIBC_MINOR__
+
 namespace crucible {
 	using namespace std;
 
@@ -73,7 +77,9 @@ namespace crucible {
 
 	typedef ResourceHandle<Process::id, Process> Pid;
 
+#ifndef SYS_GETTID
 	pid_t gettid();
+#endif  // SYS_GETTID
 	double getloadavg1();
 	double getloadavg5();
 	double getloadavg15();

--- a/lib/process.cc
+++ b/lib/process.cc
@@ -8,9 +8,11 @@
 #include <utility>
 
 // for gettid()
+#ifndef SYS_GETTID
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
+#endif // SYS_GETTID
 #include <unistd.h>
 #include <sys/syscall.h>
 
@@ -114,11 +116,13 @@ namespace crucible {
 	template<>
 	struct ResourceHandle<Process::id, Process>;
 
+#ifndef SYS_GETTID
 	pid_t
 	gettid()
 	{
 		return syscall(SYS_gettid);
 	}
+#endif // SYS_GETTID
 
 	double
 	getloadavg1()


### PR DESCRIPTION
In version 2.30 glibc added it's own gettid() function. This resulted
in "error: call of overloaded ‘gettid()’ is ambiguous" because of bees
own implementation for gettid().

Fixes #127 