### PR TITLE
bees-context: Remove confusing log message

### DIFF
--- a/src/bees-context.cc
+++ b/src/bees-context.cc
@@ -943,7 +943,6 @@ BeesContext::stop()
 {
 	Timer stop_timer;
 	BEESLOGNOTICE("Stopping bees...");
-	BEESLOGWARN("WARNING: This feature is EXPERIMENTAL and may not work!");
 
 	BEESNOTE("setting stop_request flag");
 


### PR DESCRIPTION
Saying just "This feature" at some log levels could be puzzling. Let's
clarify what that mysterious feature could be.

Signed-off-by: Kai Krakow <kai@kaishome.de>