### PR TITLE
glibc alternative musl does not define pthread_getname_np()

### DIFF
--- a/lib/task.cc
+++ b/lib/task.cc
@@ -192,8 +192,10 @@ namespace crucible {
 		lock.unlock();
 
 		char buf[24] = { 0 };
+#ifdef _GNU_SOURCE
 		DIE_IF_MINUS_ERRNO(pthread_getname_np(pthread_self(), buf, sizeof(buf)));
 		DIE_IF_MINUS_ERRNO(pthread_setname_np(pthread_self(), m_title.c_str()));
+#endif
 
 		weak_ptr<TaskState> this_task_wp = shared_from_this();
 		swap(this_task_wp, tl_current_task_wp);

--- a/src/bees.cc
+++ b/src/bees.cc
@@ -187,10 +187,12 @@ BeesNote::get_name()
 	// OK try the pthread name next.
 	char buf[24];
 	memset(buf, '\0', sizeof(buf));
+#ifdef _GNU_SOURCE
 	int err = pthread_getname_np(pthread_self(), buf, sizeof(buf));
 	if (err) {
 		return string("pthread_getname_np: ") + strerror(err);
 	}
+#endif
 	buf[sizeof(buf) - 1] = '\0';
 
 	// thread_getname_np returns process name


### PR DESCRIPTION
This is a hack and probably wrong.