### PR TITLE
scripts: Update beescrawl.dat file name after UUID removal

### DIFF
--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -134,7 +134,7 @@ fi
     fi
     if (( "$OLD_SIZE" != "$NEW_SIZE" )); then
         INFO "Resize db: $OLD_SIZE -> $NEW_SIZE"
-        [ -f "$BEESHOME/beescrawl.$UUID.dat" ] && rm "$BEESHOME/beescrawl.$UUID.dat"
+        [ -f "$BEESHOME/beescrawl.dat" ] && rm "$BEESHOME/beescrawl.dat"
         truncate -s $NEW_SIZE $DB_PATH
     fi
     chmod 700 "$DB_PATH"

--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -134,7 +134,7 @@ fi
     fi
     if (( "$OLD_SIZE" != "$NEW_SIZE" )); then
         INFO "Resize db: $OLD_SIZE -> $NEW_SIZE"
-        [ -f "$BEESHOME/beescrawl.dat" ] && rm "$BEESHOME/beescrawl.dat"
+        rm -f "$BEESHOME/beescrawl.dat"
         truncate -s $NEW_SIZE $DB_PATH
     fi
     chmod 700 "$DB_PATH"


### PR DESCRIPTION
Commit 06e111c229331e152656e1840646a862a4410503 removed the UUID from
the beescrawl.dat file name, but this change was not also applied to
the wrapper script. Do that now.