### PR TITLE
bees: Avoid unused result with -Werror=unused-result

### DIFF
--- a/src/bees.cc
+++ b/src/bees.cc
@@ -241,7 +241,7 @@ bees_readahead(int const fd, off_t offset, size_t size)
 		size_t this_read_size = min(size, sizeof(dummy));
 		// Ignore errors and short reads.
 		// It turns out our size parameter isn't all that accurate.
-		pread(fd, dummy, this_read_size, offset);
+		(void)!pread(fd, dummy, this_read_size, offset);
 		BEESCOUNT(readahead_count);
 		BEESCOUNTADD(readahead_bytes, this_read_size);
 		offset += this_read_size;


### PR DESCRIPTION
Fixes: commit 20b8f8ae0b392 ("bees: use helper function for readahead")
Signed-off-by: Kai Krakow <kai@kaishome.de>