### PR TITLE
Add MOUNT_OPTIONS to scripts/beesd.in and use PrivateMounts=true

### DIFF
--- a/scripts/beesd.conf.sample
+++ b/scripts/beesd.conf.sample
@@ -18,6 +18,9 @@ UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ## Options to apply, see `beesd --help` for details
 # OPTIONS="--strip-paths --no-timestamps"
 
+## Mount options 
+# MOUNT_OPTIONS=""
+
 ## Bees DB size
 # Hash Table Sizing
 # sHash table entries are 16 bytes each

--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -91,6 +91,7 @@ MNT_DIR="${MNT_DIR:-$WORK_DIR/mnt/$UUID}"
 BEESHOME="${BEESHOME:-$MNT_DIR/.beeshome}"
 BEESSTATUS="${BEESSTATUS:-$WORK_DIR/$UUID.status}"
 DB_SIZE="${DB_SIZE:-$((8192*AL128K))}"
+MOUNT_OPTIONS="${MOUNT_OPTIONS-}"
 
 INFO "Check: Disk exists"
 if [ ! -b "/dev/disk/by-uuid/$UUID" ]; then
@@ -114,7 +115,7 @@ umount_w(){ mountpoint -q "$1" && umount -l "$1"; }
 force_umount(){ umount_w "$MNT_DIR"; }
 trap force_umount SIGINT SIGTERM EXIT
 
-mount -osubvolid=5 /dev/disk/by-uuid/$UUID "$MNT_DIR" || exit 1
+mount -osubvolid=5 -o "$MOUNT_OPTIONS" /dev/disk/by-uuid/$UUID "$MNT_DIR" || exit 1
 
 if [ ! -d "$BEESHOME" ]; then
     INFO "Create subvol $BEESHOME for store bees data"

--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -111,11 +111,7 @@ mkdir -p "$WORK_DIR" || exit 1
 INFO "MOUNT DIR: $MNT_DIR"
 mkdir -p "$MNT_DIR" || exit 1
 
-umount_w(){ mountpoint -q "$1" && umount -l "$1"; }
-force_umount(){ umount_w "$MNT_DIR"; }
-trap force_umount SIGINT SIGTERM EXIT
-
-mount -osubvolid=5 -o "$MOUNT_OPTIONS" /dev/disk/by-uuid/$UUID "$MNT_DIR" || exit 1
+mount --make-private -osubvolid=5 -o "$MOUNT_OPTIONS" /dev/disk/by-uuid/$UUID "$MNT_DIR" || exit 1
 
 if [ ! -d "$BEESHOME" ]; then
     INFO "Create subvol $BEESHOME for store bees data"
@@ -144,4 +140,4 @@ fi
 MNT_DIR="$(realpath $MNT_DIR)"
 
 cd "$MNT_DIR"
-"$bees_bin" "${ARGUMENTS[@]}" $OPTIONS "$MNT_DIR"
+exec "$bees_bin" "${ARGUMENTS[@]}" $OPTIONS "$MNT_DIR"

--- a/scripts/beesd@.service.in
+++ b/scripts/beesd@.service.in
@@ -20,5 +20,7 @@ Restart=on-abnormal
 StartupCPUWeight=25
 StartupIOWeight=25
 
+PrivateMounts=true
+
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
Add MOUNT_OPTIONS to scripts/beesd.in so that user can specify compression level and use PrivateMounts=true in systemd unit so that the btrfs mountpoint won't be available to other process and can be automatically umounted reliably, without having to keep the bash process around.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>