### PR TITLE
Remove MOUNT_OPTIONS for it is useless and could cause undocumented behavior if btrfs mount options are specified

### DIFF
--- a/scripts/beesd.conf.sample
+++ b/scripts/beesd.conf.sample
@@ -18,9 +18,6 @@ UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ## Options to apply, see `beesd --help` for details
 # OPTIONS="--strip-paths --no-timestamps"
 
-## Mount options
-# MOUNT_OPTIONS=""
-
 ## Bees DB size
 # Hash Table Sizing
 # sHash table entries are 16 bytes each

--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -91,7 +91,7 @@ MNT_DIR="${MNT_DIR:-$WORK_DIR/mnt/$UUID}"
 BEESHOME="${BEESHOME:-$MNT_DIR/.beeshome}"
 BEESSTATUS="${BEESSTATUS:-$WORK_DIR/$UUID.status}"
 DB_SIZE="${DB_SIZE:-$((8192*AL128K))}"
-MOUNT_OPTIONS="${MOUNT_OPTIONS-}"
+MOUNT_OPTIONS="${MOUNT_OPTIONS:-}"
 
 INFO "Check: Disk exists"
 if [ ! -b "/dev/disk/by-uuid/$UUID" ]; then

--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -91,7 +91,7 @@ MNT_DIR="${MNT_DIR:-$WORK_DIR/mnt/$UUID}"
 BEESHOME="${BEESHOME:-$MNT_DIR/.beeshome}"
 BEESSTATUS="${BEESSTATUS:-$WORK_DIR/$UUID.status}"
 DB_SIZE="${DB_SIZE:-$((8192*AL128K))}"
-MOUNT_OPTIONS="${MOUNT_OPTIONS:-}"
+MOUNT_OPTIONS="${MOUNT_OPTIONS:-noatime,nodev,noexec,nosuid}"
 
 INFO "Check: Disk exists"
 if [ ! -b "/dev/disk/by-uuid/$UUID" ]; then

--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -91,7 +91,6 @@ MNT_DIR="${MNT_DIR:-$WORK_DIR/mnt/$UUID}"
 BEESHOME="${BEESHOME:-$MNT_DIR/.beeshome}"
 BEESSTATUS="${BEESSTATUS:-$WORK_DIR/$UUID.status}"
 DB_SIZE="${DB_SIZE:-$((8192*AL128K))}"
-MOUNT_OPTIONS="${MOUNT_OPTIONS:-noatime,nodev,noexec,nosuid}"
 
 INFO "Check: Disk exists"
 if [ ! -b "/dev/disk/by-uuid/$UUID" ]; then
@@ -111,7 +110,7 @@ mkdir -p "$WORK_DIR" || exit 1
 INFO "MOUNT DIR: $MNT_DIR"
 mkdir -p "$MNT_DIR" || exit 1
 
-mount --make-private -osubvolid=5 -o "$MOUNT_OPTIONS" /dev/disk/by-uuid/$UUID "$MNT_DIR" || exit 1
+mount --make-private -osubvolid=5 /dev/disk/by-uuid/$UUID "$MNT_DIR" || exit 1
 
 if [ ! -d "$BEESHOME" ]; then
     INFO "Create subvol $BEESHOME for store bees data"


### PR DESCRIPTION
Fixed missing `:` in #188