### PR TITLE
Add a meson build system for bees

### DIFF
--- a/docs/index.py
+++ b/docs/index.py
@@ -1,0 +1,5 @@
+import sys
+
+# Rewrite relative links in index file to remove 'docs/' prefix
+with open(sys.argv[1]) as file:
+    sys.stdout.write(file.read().replace('docs/', ''))

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,8 +60,43 @@ If you want to start hacking on bees and contribute changes, just emerge
 the live version which automatically pulls in all required development
 packages.
 
-Build from source
------------------
+Build from source with meson
+-----------------------------
+
+The quick steps to build and test:
+
+```sh
+$ cd /path/to/source/bees
+$ meson builddir && cd builddir
+$ meson compile
+$ meson test
+```
+
+The build produces `src/bees` in the `builddir`.
+
+It will also generate `scripts/beesd@.service` for systemd users. This
+service makes use of a helper script `scripts/beesd` to boot the service.
+Both of the latter use the filesystem UUID to mount the root subvolume
+within a temporary runtime directory.
+
+You can install these files to the configured prefix using `meson install`
+or manually copy them as you like.
+
+Depending on your Linux distribution, you may need to install some
+dependencies first:
+
+### Ubuntu 16.04 - 17.04:
+```sh
+$ apt -y install build-essential btrfs-tools markdown meson
+```
+
+### Ubuntu 18.10:
+```sh
+$ apt -y install build-essential btrfs-progs markdown meson
+```
+
+Build from source with make
+---------------------------
 
 Build with `make`. The build produces `bin/bees` which must be copied
 to somewhere in `$PATH` on the target system respectively.
@@ -80,12 +115,11 @@ within a temporary runtime directory.
 Packaging
 ---------
 
-See 'Dependencies' below. Package maintainers can pick ideas for building and
+See 'Dependencies' above. Package maintainers can pick ideas for building and
 configuring the source package from the Gentoo ebuild:
 
 <https://github.com/gentoo/gentoo/tree/master/sys-fs/bees>
 
-You can configure some build options by creating a file `localconf` and
-adjust settings for your distribution environment there.
-
-Please also review the Makefile for additional hints.
+When using the `make` build system, you can configure some build options by
+creating a file `localconf` and adjust settings for your distribution
+environment there. Please also review the Makefile for additional hints.

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,0 +1,46 @@
+markdown_bin = find_program(
+  'cmark-gfm', 'redcarpet', 'markdown2', 'markdown', 'markdown_py',
+  disabler: true,
+  required: get_option('docs')
+)
+
+if markdown_bin.found() and markdown_bin.full_path().endswith('cmark-gfm')
+  markdown_args = [ '-e', 'table' ]
+else
+  if markdown_bin.found()
+    warning('The preferred markdown tool cmark-gfm was not found, you will not get Github-style tables.')
+  endif
+  markdown_args = []
+endif
+
+index_md = custom_target(
+  input: [ 'index.py', '../README.md' ],
+  output: 'index.md',
+  command: [ python, '@INPUT@' ],
+  capture: true,
+)
+
+docs_md = [
+  'btrfs-kernel.md',
+  'btrfs-other.md',
+  'config.md',
+  'event-counters.md',
+  'gotchas.md',
+  'how-it-works.md',
+  'install.md',
+  'missing.md',
+  'options.md',
+  'running.md',
+  'wrong.md',
+  index_md,
+]
+
+foreach doc_md: docs_md
+  custom_target(
+    build_by_default: true,
+    capture: true,
+    command: [ markdown_bin ] + markdown_args + '@INPUT@',
+    input: doc_md,
+    output: '@BASENAME@.html',
+  )
+endforeach

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,0 +1,30 @@
+crucible_version_cc = vcs_tag(
+  input: 'version.cc.in',
+  output: 'version.cc',
+  replace_string: '@VERSION@',
+)
+
+crucible_lib = static_library(
+  'crucible',
+  [
+    'bytevector.cc',
+    'chatter.cc',
+    'city.cc',
+    'cleanup.cc',
+    'crc64.cc',
+    'error.cc',
+    'extentwalker.cc',
+    'fd.cc',
+    'fs.cc',
+    'ntoa.cc',
+    'path.cc',
+    'process.cc',
+    'string.cc',
+    'task.cc',
+    'time.cc',
+    'uname.cc',
+    crucible_version_cc,
+  ],
+  dependencies: [ thread_dep ],
+  include_directories: [ inc ],
+)

--- a/lib/version.cc.in
+++ b/lib/version.cc.in
@@ -1,0 +1,1 @@
+namespace crucible { const char *VERSION = "@VERSION@"; }

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,33 @@
+project(
+  'bees',
+  [ 'c', 'cpp', ],
+  default_options : [
+    'warning_level=3',
+    'c_std=c99',
+    'cpp_std=c++11',
+  ],
+  license: 'GPL-3.0-or-later',
+  version : '0.7',
+)
+
+# Helper scripts for source generation are written in python.
+# Use the same python as meson was run with.
+pymod = import('python')
+python = pymod.find_installation()
+
+systemd_dep = dependency('systemd', disabler: true, required: get_option('systemd'))
+systemdsystemunitdir = systemd_dep.get_variable('systemdsystemunitdir')
+
+# This is meson automagic to figure out how to enable pthreads
+thread_dep = dependency('threads')
+
+inc = include_directories('include')
+
+beesconfdir = get_option('sysconfdir') / 'bees'
+beeslibdir = get_option('libdir') / 'bees'
+
+subdir('lib')
+subdir('src')
+subdir('test')
+subdir('docs')
+subdir('scripts')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('docs', type: 'feature', value: 'auto',
+  description: 'Build HTML documentation from Markdown source')
+option('systemd', type: 'feature', value: 'auto',
+  description: 'Install systemd unit files')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,5 @@ option('docs', type: 'feature', value: 'auto',
   description: 'Build HTML documentation from Markdown source')
 option('systemd', type: 'feature', value: 'auto',
   description: 'Install systemd unit files')
+option('tools', type: 'boolean', value: false,
+  description: 'Install fiemap and fiewalk helper tools')

--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -31,7 +31,7 @@ help(){
     exec "$bees_bin" --help
 }
 
-for i in $(/usr/lib/bees/bees --help 2>&1 | grep "\-\-" | sed -e "s/^[^-]*-/-/" -e "s/,[^-]*--/ --/" -e "s/ [^-]*$//")
+for i in $("$bees_bin" --help 2>&1 | grep "\-\-" | sed -e "s/^[^-]*-/-/" -e "s/,[^-]*--/ --/" -e "s/ [^-]*$//")
 do
    TMP_ARGS="$TMP_ARGS $i"
 done

--- a/scripts/meson.build
+++ b/scripts/meson.build
@@ -1,0 +1,25 @@
+scripts_config = configuration_data({
+  'PREFIX': get_option('prefix'),
+  'ETC_PREFIX': get_option('prefix') / get_option('sysconfdir'),
+  'LIBEXEC_PREFIX': get_option('prefix') / beeslibdir,
+})
+
+configure_file(
+  configuration: scripts_config,
+  input: 'beesd.in',
+  install: true,
+  install_dir: get_option('sbindir'),
+  install_mode: 'rwxr-xr-x',
+  output: 'beesd',
+)
+
+configure_file(
+  configuration: scripts_config,
+  input: 'beesd@.service.in',
+  install: true,
+  install_dir: systemdsystemunitdir,
+  install_mode: 'rw-r--r--',
+  output: 'beesd@.service',
+)
+
+install_data('beesd.conf.sample', install_dir: beesconfdir, install_mode: 'rw-r--r--')

--- a/src/bees-usage.py
+++ b/src/bees-usage.py
@@ -1,0 +1,9 @@
+import sys
+
+c_str_escape = str.maketrans({'\n': '\\n', '"': '\\"', '\\': '\\\\'})
+
+print("const char *BEES_USAGE = ")
+with open(sys.argv[1]) as file:
+    for line in file:
+        print('"{}"'.format(line.translate(c_str_escape)))
+print(";")

--- a/src/bees-version.c.in
+++ b/src/bees-version.c.in
@@ -1,0 +1,1 @@
+const char *BEES_VERSION = "@VERSION@";

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,50 @@
+bees_version_c = vcs_tag(
+  input: 'bees-version.c.in',
+  output: 'bees-version.c',
+  replace_string: '@VERSION@',
+)
+
+bees_usage_c = custom_target(
+  input: [ 'bees-usage.py', 'bees-usage.txt' ],
+  output: 'bees-usage.c',
+  command: [ python, '@INPUT@' ],
+  capture: true,
+)
+
+executable(
+  'bees',
+  [
+    'bees.cc',
+    'bees-context.cc',
+    'bees-hash.cc',
+    'bees-resolve.cc',
+    'bees-roots.cc',
+    'bees-thread.cc',
+    'bees-trace.cc',
+    'bees-types.cc',
+    bees_version_c,
+    bees_usage_c,
+  ],
+  dependencies: [ thread_dep ],
+  include_directories: [ inc ],
+  install: true,
+  install_dir: beeslibdir,
+  link_with: [ crucible_lib ],
+)
+
+executable(
+  'fiemap',
+  [ 'fiemap.cc' ],
+  include_directories: [ inc ],
+  install: true,
+  link_with: [ crucible_lib ],
+)
+
+executable(
+  'fiewalk',
+  [ 'fiewalk.cc' ],
+  include_directories: [ inc ],
+  install: true,
+  install_dir: get_option('sbindir'),
+  link_with: [ crucible_lib ],
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -36,7 +36,7 @@ executable(
   'fiemap',
   [ 'fiemap.cc' ],
   include_directories: [ inc ],
-  install: true,
+  install: get_option('tools'),
   link_with: [ crucible_lib ],
 )
 
@@ -44,7 +44,7 @@ executable(
   'fiewalk',
   [ 'fiewalk.cc' ],
   include_directories: [ inc ],
-  install: true,
+  install: get_option('tools'),
   install_dir: get_option('sbindir'),
   link_with: [ crucible_lib ],
 )

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,23 @@
+tests = [
+  'chatter',
+  'crc64',
+  'fd',
+  'limits',
+  'namedptr',
+  'path',
+  'process',
+  'progress',
+  'task'
+]
+
+test_workdir = meson.current_source_dir()
+
+foreach test_name: tests
+  exe = executable(
+    test_name,
+    [ '@0@.cc'.format(test_name) ],
+    include_directories: [ inc ],
+    link_with: [ crucible_lib ],
+  )
+  test(test_name, exe, workdir: test_workdir)
+endforeach


### PR DESCRIPTION
To assist in packaging and make the installation process a bit more predictable (I can read Makefiles, but I don't *like* to read Makefiles…) I've created a build system for bees using meson.

As best I can tell, it correctly builds the applications, documentation, and runs tests. If you use `meson configure --sysconfdir=/etc --prefix=/usr` then it will match the install locations of the current `make install`.

Some options are provided (see `meson_options.txt`) to allow enabling/disabling some optional features - generating html documentation, installing systemd unit files, and installing the extra `fiemap` and `fiewalk` tools.

Some of the file generation that was previously done with sed and shell in the makefiles is done with python scripts in the meson build. Since meson is present, we're guaranteed to have a python, and it is a bit easier to work with external scripts in the meson build system then attempt to do inline shell.