### PR TITLE
Fix beesd script arg parsing to respect PREFIX

### DIFF
--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -31,7 +31,7 @@ help(){
     exec "$bees_bin" --help
 }
 
-for i in $(/usr/lib/bees/bees --help 2>&1 | grep "\-\-" | sed -e "s/^[^-]*-/-/" -e "s/,[^-]*--/ --/" -e "s/ [^-]*$//")
+for i in $("$bees_bin" --help 2>&1 | grep "\-\-" | sed -e "s/^[^-]*-/-/" -e "s/,[^-]*--/ --/" -e "s/ [^-]*$//")
 do
    TMP_ARGS="$TMP_ARGS $i"
 done


### PR DESCRIPTION
Without this, if you install to a different PREFIX such as /usr/local
it will fail to recognize any arguments and if you use the systemd unit,
that makes --no-timestamps the first NOT_SUPPORTED_ARG which will get
passed to uuidparse, which doesn't recognize it and errors.