### PR TITLE
using device mapper name for systemd unit instead

### DIFF
--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -19,12 +19,6 @@ readonly bees_bin=$(realpath @LIBEXEC_PREFIX@/bees)
 
 command -v "$bees_bin" &> /dev/null || ERRO "Missing 'bees' agent"
 
-uuid_valid(){
-    if uuidparse -n -o VARIANT $1 | grep -i -q invalid; then
-        false
-    fi
-}
-
 help(){
     echo "Usage: beesd [options] <btrfs_uuid>"
     echo "- - -"
@@ -62,9 +56,13 @@ for arg in "${ARGUMENTS[@]}"; do
 done
 
 for arg in "${NOT_SUPPORTED_ARGS[@]}"; do
-    if uuid_valid $arg; then
-        [ ! -z "$UUID" ] && help
-        UUID=$arg
+    if [ ! -z "$(blkid --uuid $arg -o value | head -1)" ]; then
+        UUID="$arg"
+        INFO "Using UUID $arg"
+    fi
+    if [ ! -z "$(blkid /dev/mapper/$arg -o value | head -1)" ]; then
+        UUID="$(blkid /dev/mapper/$arg -o value | head -1)"
+        INFO "Found $UUID for $arg"
     fi
 done
 

--- a/scripts/beesd@.service.in
+++ b/scripts/beesd@.service.in
@@ -1,7 +1,8 @@
 [Unit]
 Description=Bees (%i)
 Documentation=https://github.com/Zygo/bees
-After=sysinit.target
+#After=sysinit.target
+After=local-fs.target
 
 [Service]
 Type=simple
@@ -56,4 +57,4 @@ AmbientCapabilities=CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_SYS_ADMI
 NoNewPrivileges=true
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target


### PR DESCRIPTION
Why don't we use the mapper name in the systemd unit alias, the uuid is kinda ugly when I do `systemctl status`.

Also, I don't have uuidparse on my system.

I also needed the multi-user.target patch because I use lvm and my btrfs is on top of it.
Nevertheless it seems to be working in my build system machine. Thanks for the nice project I use for saving space of my stupid `.o` objects.
