### PR TITLE
Makefile: also drop fiemap and fiewalk from main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,6 @@ scripts/%: scripts/%.in
 
 scripts: scripts/beesd scripts/beesd@.service
 
-install_tools: ## Install support tools + libs
-install_tools: src
-	install -Dm755 bin/fiemap $(DESTDIR)$(PREFIX)/bin/fiemap
-	install -Dm755 bin/fiewalk $(DESTDIR)$(PREFIX)/sbin/fiewalk
-
 install_bees: ## Install bees + libs
 install_bees: src $(RUN_INSTALL_TESTS)
 	install -Dm755 bin/bees	$(DESTDIR)$(LIBEXEC_PREFIX)/bees
@@ -67,7 +62,7 @@ ifneq ($(SYSTEMD_SYSTEM_UNIT_DIR),)
 endif
 
 install: ## Install distribution
-install: install_bees install_scripts $(OPTIONAL_INSTALL_TARGETS)
+install: install_bees install_scripts
 
 help: ## Show help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##/\t/'


### PR DESCRIPTION
Fixes: https://github.com/Zygo/bees/commit/ccd8dcd43f0c903a94367817a0a9e94034a5cce4
Signed-off-by: Kai Krakow <kai@kaishome.de>