### PR TITLE
Make exit status on help message success

### DIFF
--- a/src/bees.cc
+++ b/src/bees.cc
@@ -693,7 +693,10 @@ bees_main(int argc, char *argv[])
 				break;
 
 			case 'h':
+				do_cmd_help(argv);
+				return EXIT_SUCCESS;
 			default:
+				BEESLOGNOTICE("Error in command line arguments.");
 				do_cmd_help(argv);
 				return EXIT_FAILURE;
 		}


### PR DESCRIPTION
Hi there,

First of all, thanks a lot for your work on this very helpful and powerful tool.

I was surprised today to note that bees exits with an error code, 1, when one does `beesd --help`. I believe standard behaviour (and logic?) is to exit with success in this case, since the user asked for a help message, and the program gave it, so everything was "successful", right?

If you disagree just feel free to close this.
Best regards,
Mark.