### PR TITLE
context: demote "abandoned toxic match" to debug log level

### DIFF
--- a/src/bees-context.cc
+++ b/src/bees-context.cc
@@ -471,7 +471,7 @@ BeesContext::scan_one_extent(const BeesFileRange &bfr, const Extent &e)
 
 			// Hash is toxic
 			if (found_addr.is_toxic()) {
-				BEESLOGWARN("WORKAROUND: abandoned toxic match for hash " << hash << " addr " << found_addr << " matching bbd " << bbd);
+				BEESLOGDEBUG("WORKAROUND: abandoned toxic match for hash " << hash << " addr " << found_addr << " matching bbd " << bbd);
 				// Don't push these back in because we'll never delete them.
 				// Extents may become non-toxic so give them a chance to expire.
 				// hash_table->push_front_hash_addr(hash, found_addr);


### PR DESCRIPTION
This log message creates a overwhelmingly lot of messages in the system journal, leading to write-back flushing storms under high activity. As it is a work-around message, it is probably only useful to developers, thus demote to debug level.

This fixes latency spikes in desktop usage after adding a lot of new files, especially since systemd-journal starts to flush caches if it sees memory pressure.