### PR TITLE
Disable warning-as-error

### DIFF
--- a/makeflags
+++ b/makeflags
@@ -1,11 +1,11 @@
 # Default:
-CCFLAGS = -Wall -Wextra -Werror -O3
+CCFLAGS = -Wall -Wextra -O3
 
 # Optimized:
-# CCFLAGS = -Wall -Wextra -Werror -O3 -march=native
+# CCFLAGS = -Wall -Wextra -O3 -march=native
 
 # Debug:
-# CCFLAGS = -Wall -Wextra -Werror -O0 -ggdb
+# CCFLAGS = -Wall -Wextra -O0 -ggdb
 
 CCFLAGS += -I../include -D_FILE_OFFSET_BITS=64
 


### PR DESCRIPTION
Breaks compilation on newer versions of GCC. Likely better to leave this up to the build system.