### PR TITLE
[PATCH] Add configurable bindir for distros without sbin

### DIFF
--- a/Defines.mk
+++ b/Defines.mk
@@ -4,6 +4,7 @@ define TEMPLATE_COMPILER =
 sed $< >$@ \
 		-e's#@DESTDIR@#$(DESTDIR)#' \
 		-e's#@PREFIX@#$(PREFIX)#' \
+		-e's#@BINDIR@#$(BINDIR)#' \
 		-e's#@ETC_PREFIX@#$(ETC_PREFIX)#' \
 		-e's#@LIBEXEC_PREFIX@#$(LIBEXEC_PREFIX)#'
 endef

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PREFIX ?= /usr
 ETC_PREFIX ?= /etc
 LIBDIR ?= lib
+BINDIR ?= sbin
 
 LIB_PREFIX ?= $(PREFIX)/$(LIBDIR)
 LIBEXEC_PREFIX ?= $(LIB_PREFIX)/bees
@@ -55,7 +56,7 @@ install_bees: src $(RUN_INSTALL_TESTS)
 
 install_scripts: ## Install scipts
 install_scripts: scripts
-	install -Dm755 scripts/beesd $(DESTDIR)$(PREFIX)/sbin/beesd
+	install -Dm755 scripts/beesd $(DESTDIR)$(PREFIX)/$(BINDIR)/beesd
 	install -Dm644 scripts/beesd.conf.sample $(DESTDIR)$(ETC_PREFIX)/bees/beesd.conf.sample
 ifneq ($(SYSTEMD_SYSTEM_UNIT_DIR),)
 	install -Dm644 scripts/beesd@.service $(DESTDIR)$(SYSTEMD_SYSTEM_UNIT_DIR)/beesd@.service

--- a/scripts/beesd@.service.in
+++ b/scripts/beesd@.service.in
@@ -5,7 +5,7 @@ After=sysinit.target
 
 [Service]
 Type=simple
-ExecStart=@PREFIX@/sbin/beesd --no-timestamps %i
+ExecStart=@PREFIX@/@BINDIR@/beesd --no-timestamps %i
 CPUAccounting=true
 CPUSchedulingPolicy=batch
 CPUWeight=12


### PR DESCRIPTION
Fedora is about to drop the concept of /usr/sbin entirely, so this change allows a BINDIR to be specified during build and respected.