### PR TITLE
Add Dockerfile for build deb-package (Ubuntu 24.04)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ localconf
 lib/configure.h
 scripts/beesd
 scripts/beesd@.service
+deb/

--- a/Dockerfile_buildx_deb
+++ b/Dockerfile_buildx_deb
@@ -1,0 +1,54 @@
+FROM ubuntu:24.04 AS base
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y \
+     fakeroot=1.33-1 git=1:2.43.0-1ubuntu7.2 build-essential=12.10ubuntu1 \
+     devscripts=2.23.7 debhelper=13.14.1ubuntu5 dh-make=2.202304 \
+     btrfs-progs=6.6.3-1.1build2 markdown=1.0.1-12 pkg-config=1.8.1-2build1 \
+ && rm -rf /var/lib/apt/lists/*
+
+FROM base AS build
+WORKDIR /build/bees
+RUN chown -R ubuntu:ubuntu /build 
+USER ubuntu
+RUN git clone https://github.com/Zygo/bees.git .
+ARG DEBFULLNAME="Maintainer Name"
+ARG DEBEMAIL="usere@example.pro"
+RUN mkdir debian \
+ && printf "Source: bees\n\
+Section: utils\n\
+Priority: optional\n\
+Maintainer: %s <%s>\n\
+Build-Depends: debhelper-compat (= 13), markdown, btrfs-progs\n\
+Standards-Version: 4.5.1\n\
+Homepage: https://github.com/Zygo/bees\n\
+\n\
+Package: bees\n\
+Architecture: any\n\
+Depends: \${shlibs:Depends}, \${misc:Depends}, btrfs-progs\n\
+Description: Btrfs deduplication daemon\n\
+ A daemon that deduplicates data on Btrfs volumes using\n\
+ reflinks and stable file handles.\
+" "${DEBFULLNAME}" "${DEBEMAIL}" > debian/control \
+ && printf "#!/usr/bin/make -f\n\
+%%:\n\
+	dh \$@\n\
+\n\
+override_dh_auto_build:\n\
+	make\n\
+\n\
+override_dh_auto_install:\n\
+	make DESTDIR=\$(CURDIR)/debian/tmp SYSTEMD_SYSTEM_UNIT_DIR=/lib/systemd/system install"  > debian/rules \
+ && chmod +x debian/rules \
+ && printf "usr/sbin/beesd\n\
+usr/lib/bees/bees\n\
+etc/bees/beesd.conf.sample\n\
+lib/systemd/system/beesd@.service" >debian/install \
+ && mkdir -p debian/source && echo "3.0 (native)" > debian/source/format
+ENV EDITOR=true
+RUN bash -c 'dch --create -v $(git describe --always --dirty | sed -E 's/^[a-zA-Z]//') --package bees'\
+ && sed -E -i 's/(git clean -dfx -e localconf)/\1 -e debian\//g' Makefile \
+ && dpkg-buildpackage -us -uc
+
+FROM scratch AS final
+WORKDIR /
+COPY --from=build /build/*.deb .


### PR DESCRIPTION
Just use this command:

```
docker buildx build \
  --platform linux/amd64 \
  -t bees-deb \
  --build-arg "DEBFULLNAME=Your Name" \
  --build-arg "DEBEMAIL=your@email" \
  -f ./Dockerfile_buildx_deb \
  --output type=local,dest=./deb .
```

After this, the bees installation deb package will appear in the ./deb directory.