### PR TITLE
scripts: systemd CPUAccounting is deprecated

### DIFF
--- a/scripts/beesd@.service.in
+++ b/scripts/beesd@.service.in
@@ -6,7 +6,6 @@ After=sysinit.target
 [Service]
 Type=simple
 ExecStart=@PREFIX@/@BINDIR@/beesd --no-timestamps %i
-CPUAccounting=true
 CPUSchedulingPolicy=batch
 CPUWeight=12
 IOSchedulingClass=idle


### PR DESCRIPTION
systemd 258 has the following changes noted in systemd.resource-control(5):

> `CPUAccounting=` setting is deprecated, because it is always available on the unified cgroup hierarchy and such setting has no effect.

Closes #327