### PR TITLE
ADD the common convention to display the active version of bees(d)

### DIFF
--- a/scripts/beesd.in
+++ b/scripts/beesd.in
@@ -39,6 +39,10 @@ help(){
     exec "$bees_bin" --help
 }
 
+version(){
+    exec "$bees_bin" --version
+}
+
 for i in $("$bees_bin" --help 2>&1 | grep -E " --" | sed -e "s/^[^-]*-/-/" -e "s/,[^-]*--/ --/" -e "s/ [^-]*$//")
 do
    TMP_ARGS="$TMP_ARGS $i"
@@ -66,6 +70,8 @@ for arg in "${ARGUMENTS[@]}"; do
     case $arg in
         -h) help;;
         --help) help;;
+        -V) version;;
+        --version) version;;
     esac
 done
 

--- a/src/bees-trace.cc
+++ b/src/bees-trace.cc
@@ -2,7 +2,9 @@
 
 // tracing ----------------------------------------
 
-int bees_log_level = 8;
+/* default log level is LOG_INFO i.e.*/
+/* LOG_WARNING (4); LOG_NOTICE (5); LOG_INFO (6); LOG_DEBUG (7) */
+int bees_log_level = LOG_INFO + 1;
 
 thread_local BeesTracer *BeesTracer::tl_next_tracer = nullptr;
 thread_local bool BeesTracer::tl_first = true;

--- a/src/bees-usage.txt
+++ b/src/bees-usage.txt
@@ -6,6 +6,7 @@ Other directories will be rejected.
 
 Options:
     -h, --help            Show this help
+    -V, --version         Output version information and exit
 
 Load management options:
     -c, --thread-count    Worker thread count (default CPU count * factor)
@@ -26,7 +27,7 @@ Logging options:
     -T, --no-timestamps   Omit timestamps in log output
     -p, --absolute-paths  Show absolute paths (default)
     -P, --strip-paths     Strip $CWD from beginning of all paths in the log
-    -v, --verbose         Set maximum log level (0..8, default 8)
+    -v, --verbose         Set maximum log level (0..8, default %d)
 
 Optional environment variables:
     BEESHOME    Path to hash table and configuration files

--- a/src/bees.cc
+++ b/src/bees.cc
@@ -35,9 +35,16 @@ using namespace crucible;
 using namespace std;
 
 void
+print_version(FILE *stream=stdout)
+{
+	fprintf(stream, "bees version %s\n", BEES_VERSION);
+}
+
+void
 do_cmd_help(char *argv[])
 {
-	fprintf(stderr, BEES_USAGE, argv[0]);
+	print_version(stderr);
+	fprintf(stderr, BEES_USAGE, argv[0], bees_log_level);
 }
 
 // static inline helpers ----------------------------------------
@@ -803,6 +810,7 @@ bees_main(int argc, char *argv[])
 		{ .name = "absolute-paths",        .has_arg = no_argument,       .val = 'p' },
 		{ .name = "timestamps",            .has_arg = no_argument,       .val = 't' },
 		{ .name = "verbose",               .has_arg = required_argument, .val = 'v' },
+		{ .name = "version",               .has_arg = no_argument,       .val = 'V' },
 		{ 0 },
 	};
 
@@ -879,7 +887,10 @@ bees_main(int argc, char *argv[])
 					BEESLOGNOTICE("log level set to " << bees_log_level);
 				}
 				break;
-
+			case 'V':
+				print_version();
+				bees_log_level = LOG_WARNING + 1; //Suppress the log message at the end
+				return EXIT_SUCCESS;
 			case 'h':
 			default:
 				do_cmd_help(argv);
@@ -965,8 +976,6 @@ bees_main(int argc, char *argv[])
 int
 main(int argc, char *argv[])
 {
-	cerr << "bees version " << BEES_VERSION << endl;
-
 	if (argc < 2) {
 		do_cmd_help(argv);
 		return EXIT_FAILURE;


### PR DESCRIPTION
* In Linux (Unix), the `--version` command-line argument (or `--ver`, `-V`, `-h` for help) is a common convention to display the version of a program. While it's not a literal function call, the shell interprets this as a command-line argument that tells the program to execute its built-in version-checking routine and print the result to the terminal. E.g., `ls --version` outputs the version of the `ls` command.
* added that functionality with parameters `--version` as well as `-V` to output the version on stdout and then exit;
* Changes:
1. The default bees_log_level from 8 to 7, because the output of the version get some debugging messages too. Due to this behaviour, I will change the template with a default line `OPTIONS="--verbose 8"`

Issue: https://github.com/Zygo/bees/issues/330

BR Thomas