### PR TITLE
bees: add debian packaging support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,7 @@ help: ## Show help
 
 bees: reallyall
 fly: install
+
+deb: ## Build deb package
+deb: all
+	dpkg-buildpackage -us -uc -b

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,0 +1,5 @@
+.debhelper/
+bees/
+bees.substvars
+debhelper-build-stamp
+files

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,16 @@
+bees (0.11) unstable; urgency=low
+
+  * Much faster now.
+  * Introduces extent scan mode for dramatically increased dedupe performance,
+    particularly on VM images and snapshot-heavy workloads.
+  * Largest extents processed first for fastest free space recovery.
+  * Dynamic rate throttling via --throttle-factor.
+  * Better concurrency with dynamic thread work redistribution.
+  * Removed toxic extent workarounds, up to 100x-1000x speedup on some
+    workloads.
+  * Security improvements using openat2 syscall.
+  * SIGUSR1/SIGUSR2 support for pause/unpause without blocking file closes.
+  * Minimum recommended kernel raised to 5.7 or 5.4 LTS.
+  * Initial Debian packaging.
+
+ -- Zygo Blaxell <bees@furryterror.org>  Sun, 22 Jun 2025 00:00:00 +0000

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,13 @@
+Source: bees
+Section: admin
+Priority: optional
+Maintainer: Zygo Blaxell <bees@furryterror.org>
+Build-Depends: debhelper-compat (= 13), libbtrfs-dev, markdown
+Standards-Version: 4.6.0
+
+Package: bees
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}, btrfs-progs, util-linux
+Description: Best-Effort Extent-Same, a btrfs dedup agent
+ bees is a btrfs deduplication daemon that works on live btrfs
+ filesystems without requiring freezes or snapshots.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,8 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: bees
+Upstream-Contact: Zygo Blaxell <bees@furryterror.org>
+Source: https://github.com/Zygo/bees
+
+Files: *
+Copyright: Zygo Blaxell <bees@furryterror.org>
+License: GPL-3+

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,17 @@
+#!/usr/bin/make -f
+%:
+	dh $@
+
+override_dh_auto_configure:
+	echo 'ETC_PREFIX=/etc' > localconf
+	echo 'PREFIX=/usr' >> localconf
+	echo 'SYSTEMD_SYSTEM_UNIT_DIR=/usr/lib/systemd/system' >> localconf
+	echo 'DEFAULT_MAKE_TARGET=all' >> localconf
+	sed -i 's/ -Werror//' makeflags
+
+override_dh_auto_build:
+	$(MAKE) all
+
+override_dh_auto_install:
+	$(MAKE) install DESTDIR=$(CURDIR)/debian/bees
+	sed -i 's/"//g' $(CURDIR)/debian/bees/usr/lib/systemd/system/beesd@.service


### PR DESCRIPTION
This pull request introduces initial Debian packaging for the `bees` project, enabling the creation of `.deb` packages and providing all necessary metadata and build scripts. In addition, it documents a major new release with significant performance and feature improvements.

Debian packaging:

* Added Debian packaging files, including `control`, `rules`, `.gitignore`, and `copyright`, to support building and distributing `bees` as a Debian package. [[1]](diffhunk://#diff-2a13f1344504379e877324d3a0375adcbcb4cb27d7e575ad8f4618a52d6a00e0R1-R13) [[2]](diffhunk://#diff-889c5495b68d2a0c0d1f238818716a71939918499efbc0fc6d2994319624fc67R1-R17) [[3]](diffhunk://#diff-e5877fc095d462df4dcc5209224164bb8a2de963951147aef8612fcbb7c7f29eR1-R5) [[4]](diffhunk://#diff-248a3ad2376574c96e7b8fc79764c5a217d4d41c8bf8679bcca1c3b7b87f8ff2R1-R8)
* Updated the `Makefile` to add a `deb` target for building Debian packages using `dpkg-buildpackage`.